### PR TITLE
add logging of debug

### DIFF
--- a/extensions/eda/plugins/event_source/kubernetes.py
+++ b/extensions/eda/plugins/event_source/kubernetes.py
@@ -111,9 +111,14 @@ def load_kubernetes_api(k8s_event_api: str) -> dict:
     All the clients have the following
     syntax i.e. client.AppsV1Api() or client.AppsV1Api
     """
-    api_instance = getattr(client, k8s_event_api)()
-    k8s_watcher = watch.Watch()
-    return api_instance, k8s_watcher
+    try:
+        api_instance = getattr(client, k8s_event_api)()
+        k8s_watcher = watch.Watch()
+        logger.info("Loaded Kubernetes API: %s", k8s_event_api)
+        return api_instance, k8s_watcher
+    except AttributeError:
+        logger.error("Failed to load Kubernetes API: %s. API might be invalid.", k8s_event_api)
+        raise
 
 
 def check_method_parameters(


### PR DESCRIPTION
Hey @ccamacho  really nice work! I read on the issues of Ansible Event Driven collection and why it was not introduced as collecction :( saddly. I've been using the plugin and actually it's really good. 

The PR is to add some logging, because I was using for a while differen API versions to test them and showing the actual Kubernetes version I think is a good idea. 

I have one question
Is it possible you add this plugin to eda galaxy?


Thanks and great job!
